### PR TITLE
Add special character error messages for loader names

### DIFF
--- a/spec/commands/new_spec.rb
+++ b/spec/commands/new_spec.rb
@@ -55,6 +55,35 @@ describe 'New command' do
     expect { attempt_command('new') }.to output(expected_output).to_stdout
   end
 
+  it 'treats loader name to be downcased' do
+    ENV['EDITOR'] = 'emacs'
+
+    allow(File).to receive(:exist?).with('loaders/testing2.rb').and_return(true)
+    allow_any_instance_of(Commands::New).to receive(:system).with('emacs loaders/testing2.rb')
+    expect(File).to_not receive(:open)
+    expect(File).to_not receive(:write)
+
+    expected_output = "Editing loader\n"
+    expect { attempt_command('new Testing2') }.to output(expected_output).to_stdout
+  end
+
+  context 'outputs error message if loader name is not valid because' do
+    it 'uses kebab case' do
+      expected_output = "Invalid loader name 'im-bad-kebab-case'.".red + "\n"
+      expect { attempt_command('new im-bad-kebab-case') }.to output(expected_output).to_stdout
+    end
+
+    it 'starts terms with numbers' do
+      expected_output = "Invalid loader name 'wrong_1'.".red + "\n"
+      expect { attempt_command('new wrong_1') }.to output(expected_output).to_stdout
+    end
+
+    it 'has invalid characters' do
+      expected_output = "Invalid loader name 'wrong!'.".red + "\n"
+      expect { attempt_command('new wrong!') }.to output(expected_output).to_stdout
+    end
+  end
+
   it 'outputs warning message if default editor is not set' do
     ENV['EDITOR'] = nil
     allow(File).to receive(:exist?).with('loaders/testing.rb').and_return(true)

--- a/spec/commands/new_spec.rb
+++ b/spec/commands/new_spec.rb
@@ -29,6 +29,9 @@ describe 'New command' do
     ENV['EDITOR'] = 'emacs'
     file_obj = double('file_obj')
 
+    allow(File).to receive(:exist?)
+    allow(File).to receive(:open).and_call_original
+
     allow(File).to receive(:exist?).with('loaders/testing.rb').and_return(false)
     allow_any_instance_of(Commands::New).to receive(:system).with('emacs loaders/testing.rb')
     allow(File).to receive(:open).with('loaders/testing.rb', 'w').and_yield(file_obj)
@@ -42,10 +45,13 @@ describe 'New command' do
   it 'edits existing loader on default editor if loader already exists' do
     ENV['EDITOR'] = 'emacs'
 
+    allow(File).to receive(:exist?)
+    allow(File).to receive(:open).and_call_original
+
     allow(File).to receive(:exist?).with('loaders/testing.rb').and_return(true)
     allow_any_instance_of(Commands::New).to receive(:system).with('emacs loaders/testing.rb')
-    expect(File).to_not receive(:open)
-    expect(File).to_not receive(:write)
+    expect(File).to_not receive(:open).with('loaders/testing.rb')
+    expect(File).to_not receive(:write).with('loaders/testing.rb')
 
     expected_output = "Editing loader\n"
     output = capture_stdout_from { attempt_command('new testing') }
@@ -61,10 +67,13 @@ describe 'New command' do
   it 'treats loader name to be downcased' do
     ENV['EDITOR'] = 'emacs'
 
+    allow(File).to receive(:exist?)
+    allow(File).to receive(:open).and_call_original
+
     allow(File).to receive(:exist?).with('loaders/testing2.rb').and_return(true)
     allow_any_instance_of(Commands::New).to receive(:system).with('emacs loaders/testing2.rb')
-    expect(File).to_not receive(:open)
-    expect(File).to_not receive(:write)
+    expect(File).to_not receive(:open).with('loaders/testing2.rb')
+    expect(File).to_not receive(:write).with('loaders/testing2.rb')
 
     expected_output = "Editing loader\n"
     output = capture_stdout_from { attempt_command('new Testing2') }

--- a/spec/commands/new_spec.rb
+++ b/spec/commands/new_spec.rb
@@ -37,7 +37,10 @@ describe 'New command' do
     allow(File).to receive(:open).with('loaders/testing.rb', 'w').and_yield(file_obj)
     expect(file_obj).to receive(:write).with(template).once
 
-    expected_output = "Creating #{'new'.green} loader\n"
+    expected_output = <<~TEXT
+      Creating #{'new'.green} loader
+    TEXT
+
     output = capture_stdout_from { attempt_command('new testing') }
     expect(output).to eq(expected_output)
   end
@@ -53,13 +56,19 @@ describe 'New command' do
     expect(File).to_not receive(:open).with('loaders/testing.rb')
     expect(File).to_not receive(:write).with('loaders/testing.rb')
 
-    expected_output = "Editing loader\n"
+    expected_output = <<~TEXT
+      Editing loader
+    TEXT
+
     output = capture_stdout_from { attempt_command('new testing') }
     expect(output).to eq(expected_output)
   end
 
   it 'outputs error message if loader name is not provided' do
-    expected_output = "Missing #1 positional argument: 'name'".red + "\n"
+    expected_output = <<~TEXT
+      #{"Missing #1 positional argument: 'name'".red}
+    TEXT
+
     output = capture_stdout_from { attempt_command('new') }
     expect(output).to eq(expected_output)
   end
@@ -75,7 +84,10 @@ describe 'New command' do
     expect(File).to_not receive(:open).with('loaders/testing2.rb')
     expect(File).to_not receive(:write).with('loaders/testing2.rb')
 
-    expected_output = "Editing loader\n"
+    expected_output = <<~TEXT
+      Editing loader
+    TEXT
+
     output = capture_stdout_from { attempt_command('new Testing2') }
 
     expect(output).to eq(expected_output)
@@ -83,21 +95,30 @@ describe 'New command' do
 
   context 'outputs error message if loader name is not valid because' do
     it 'uses kebab case' do
-      expected_output = "Invalid loader name 'im-bad-kebab-case'.".red + "\n"
+      expected_output = <<~TEXT
+        #{"Invalid loader name 'im-bad-kebab-case'.".red}
+      TEXT
+
       output = capture_stdout_from { attempt_command('new im-bad-kebab-case') }
 
       expect(output).to eq(expected_output)
     end
 
     it 'starts terms with numbers' do
-      expected_output = "Invalid loader name 'wrong_1'.".red + "\n"
+      expected_output = <<~TEXT
+        #{"Invalid loader name 'wrong_1'.".red}
+      TEXT
+
       output = capture_stdout_from { attempt_command('new wrong_1') }
 
       expect(output).to eq(expected_output)
     end
 
     it 'has invalid characters' do
-      expected_output = "Invalid loader name 'wrong!'.".red + "\n"
+      expected_output = <<~TEXT
+        #{"Invalid loader name 'wrong!'.".red}
+      TEXT
+
       output = capture_stdout_from { attempt_command('new wrong!') }
 
       expect(output).to eq(expected_output)
@@ -109,7 +130,11 @@ describe 'New command' do
     allow(File).to receive(:exist?).with('loaders/testing.rb').and_return(true)
     expect_any_instance_of(Commands::New).to_not receive(:system)
 
-    expected_output = "Editing loader\n#{"Could not open loader because default editor isn't set.".yellow}\n"
+    expected_output = <<~TEXT
+      Editing loader
+      #{"Could not open loader because default editor isn't set.".yellow}
+    TEXT
+
     output = capture_stdout_from { attempt_command('new testing') }
 
     expect(output).to eq(expected_output)

--- a/spec/commands/new_spec.rb
+++ b/spec/commands/new_spec.rb
@@ -67,23 +67,31 @@ describe 'New command' do
     expect(File).to_not receive(:write)
 
     expected_output = "Editing loader\n"
-    expect { attempt_command('new Testing2') }.to output(expected_output).to_stdout
+    output = capture_stdout_from { attempt_command('new Testing2') }
+
+    expect(output).to eq(expected_output)
   end
 
   context 'outputs error message if loader name is not valid because' do
     it 'uses kebab case' do
       expected_output = "Invalid loader name 'im-bad-kebab-case'.".red + "\n"
-      expect { attempt_command('new im-bad-kebab-case') }.to output(expected_output).to_stdout
+      output = capture_stdout_from { attempt_command('new im-bad-kebab-case') }
+
+      expect(output).to eq(expected_output)
     end
 
     it 'starts terms with numbers' do
       expected_output = "Invalid loader name 'wrong_1'.".red + "\n"
-      expect { attempt_command('new wrong_1') }.to output(expected_output).to_stdout
+      output = capture_stdout_from { attempt_command('new wrong_1') }
+
+      expect(output).to eq(expected_output)
     end
 
     it 'has invalid characters' do
       expected_output = "Invalid loader name 'wrong!'.".red + "\n"
-      expect { attempt_command('new wrong!') }.to output(expected_output).to_stdout
+      output = capture_stdout_from { attempt_command('new wrong!') }
+
+      expect(output).to eq(expected_output)
     end
   end
 
@@ -94,6 +102,7 @@ describe 'New command' do
 
     expected_output = "Editing loader\n#{"Could not open loader because default editor isn't set.".yellow}\n"
     output = capture_stdout_from { attempt_command('new testing') }
+
     expect(output).to eq(expected_output)
   end
 end

--- a/utils/commands/new.rb
+++ b/utils/commands/new.rb
@@ -3,11 +3,12 @@ module Commands
     ALIASES = %w[n e edit].freeze
     DESCRIPTION = 'Creates new loader, unless it already exists. Also opens the loader on you default editor.'.freeze
     ARGS = {
-      name: 'Loaders name in snake case.'
+      name: 'Loaders name in snake case. The terms must be divided by underscore(_), and must not start with a number.',
     }.freeze
 
     def execute
-      name = obrigatory_positional_arg(0) || return
+      name = obrigatory_positional_arg(0)&.downcase || return
+      return puts("Invalid loader name '#{name}'.".red) unless is_loader_name?(name)
       path = "loaders/#{name}.rb"
 
       template = File.read('templates/loader.rb')

--- a/utils/commands/new.rb
+++ b/utils/commands/new.rb
@@ -3,12 +3,13 @@ module Commands
     ALIASES = %w[n e edit].freeze
     DESCRIPTION = 'Creates new loader, unless it already exists. Also opens the loader on you default editor.'.freeze
     ARGS = {
-      name: 'Loaders name in snake case. The terms must be divided by underscore(_), and must not start with a number.',
+      name: 'Loaders name in snake case. The terms must be divided by underscore(_), and must not start with a number.'
     }.freeze
 
     def execute
       name = obrigatory_positional_arg(0)&.downcase || return
       return puts("Invalid loader name '#{name}'.".red) unless is_loader_name?(name)
+
       path = "loaders/#{name}.rb"
 
       template = File.read('templates/loader.rb')

--- a/utils/string.rb
+++ b/utils/string.rb
@@ -9,3 +9,7 @@ end
 def camelize(string)
   string.split('_').collect(&:capitalize).join
 end
+
+def is_loader_name?(string)
+  string =~ /^[a-z][a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/
+end


### PR DESCRIPTION
## Solution
This solution includes treating loader names to be downcased on 'new' command. Then, if the loader's name doesn't comply to the new updated name arg description on the 'new' command, it output an error and fails gracefully.

## Related Links
closes #2 