### PR TITLE
Fix Base Loader crashing postwoman when it has syntax errors

### DIFF
--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -13,16 +13,20 @@ def create_loader_base_unless_exists
 end
 
 def load_loaders
-  load 'loaders/base.rb'
+  return unless load_loader('loaders/base.rb')
+
   Dir[File.dirname(__FILE__) + '/../loaders/**/*.rb'].each do |file|
-    begin
-      load file
-    rescue Exception => e
-      puts "Loader '#{file.split('/').last[..-4]}' has syntax errors and couldn't be loaded:".red
-      puts e.full_message
-      return
-    end
+    load_loader(file)
   end
+end
+
+def load_loader(loader_path)
+  load loader_path
+  true
+rescue Exception => e
+  puts "Loader '#{loader_path.split('/').last[..-4]}' has syntax errors and couldn't be loaded:".red
+  puts e.full_message
+  false
 end
 
 create_loader_base_unless_exists

--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -22,11 +22,9 @@ end
 
 def load_loader(loader_path)
   load loader_path
-  true
 rescue Exception => e
   puts "Loader '#{loader_path.split('/').last[..-4]}' has syntax errors and couldn't be loaded:".red
   puts e.full_message
-  false
 end
 
 create_loader_base_unless_exists


### PR DESCRIPTION
## Motivation
The base loader, which has higher priority than other loaders, was being imported in a separated part of the code, and wasn't being rescued properly, resulting in the whole program breaking on any syntax errors located on the base loader.

## How to reproduce
- Edit the base loader to have invalid syntax e.g.
```rb
module Loaders
  class Base < Builtin::Base
  end
# end
``` 
- Start postwoman and press enter
- Without this fix, postwoman will crash

## Solution
I've abstracted the "load loader while rescuing the process" on a method called load_loader, and called it for the base loader. Also, if this loader does not load, the others will not be processed, since they would logically break as well, polluting the users output with error messages.
