### PR TITLE
Improve bundle install prompt at startup

### DIFF
--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -1,4 +1,5 @@
 require 'rubygems'
+require 'io/console'
 
 def bundle_install_prompt
   bundle_check = `bundle check`.chomp
@@ -6,7 +7,6 @@ def bundle_install_prompt
 
   puts bundle_check
   print 'Install? [Yn] '
-  require 'io/console'
   if $stdin.getch == 'n'
     puts 'Exiting...'
     exit

--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -2,18 +2,18 @@ require 'rubygems'
 
 def bundle_install_prompt
   bundle_check = `bundle check`.chomp
-  if bundle_check != "The Gemfile's dependencies are satisfied"
-    puts bundle_check
-    print 'Install? [Yn] '
-    require 'io/console'
-    if STDIN.getch == 'n'
-      puts 'Exiting...'
-      exit
-    end
-    puts "Installing..."
+  return unless bundle_check != "The Gemfile's dependencies are satisfied"
 
-    puts `bundle install`
+  puts bundle_check
+  print 'Install? [Yn] '
+  require 'io/console'
+  if $stdin.getch == 'n'
+    puts 'Exiting...'
+    exit
   end
+  puts 'Installing...'
+
+  puts `bundle install`
 end
 
 bundle_install_prompt

--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -1,16 +1,22 @@
 require 'rubygems'
 
-bundle_check = `bundle check`.chomp
-if bundle_check != "The Gemfile's dependencies are satisfied"
-  puts bundle_check
-  puts 'Install? [Yn]'
-  if gets.chomp == 'n'
-    puts 'Exiting...'
-    exit
-  end
+def bundle_install_prompt
+  bundle_check = `bundle check`.chomp
+  if bundle_check != "The Gemfile's dependencies are satisfied"
+    puts bundle_check
+    print 'Install? [Yn] '
+    require 'io/console'
+    if STDIN.getch == 'n'
+      puts 'Exiting...'
+      exit
+    end
+    puts "Installing..."
 
-  puts `bundle install`
+    puts `bundle install`
+  end
 end
+
+bundle_install_prompt
 
 require 'bundler/setup'
 Bundler.require

--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -3,18 +3,17 @@ require 'io/console'
 
 # Prompt for installing gem dependencies if needed
 bundle_check = `bundle check`.chomp
-return unless bundle_check != "The Gemfile's dependencies are satisfied"
+if bundle_check != "The Gemfile's dependencies are satisfied"
+  puts bundle_check
+  print 'Install? [Yn] '
+  if $stdin.getch == 'n'
+    puts 'Exiting...'
+    exit
+  end
+  puts 'Installing...'
 
-puts bundle_check
-print 'Install? [Yn] '
-if $stdin.getch == 'n'
-  puts 'Exiting...'
-  exit
+  puts `bundle install`
 end
-puts 'Installing...'
-
-puts `bundle install`
-
 
 require 'bundler/setup'
 Bundler.require

--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'io/console'
 
-# Prompt for installing gem dependencies if needed
 bundle_check = `bundle check`.chomp
 if bundle_check != "The Gemfile's dependencies are satisfied"
   puts bundle_check

--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -1,22 +1,20 @@
 require 'rubygems'
 require 'io/console'
 
-def bundle_install_prompt
-  bundle_check = `bundle check`.chomp
-  return unless bundle_check != "The Gemfile's dependencies are satisfied"
+# Prompt for installing gem dependencies if needed
+bundle_check = `bundle check`.chomp
+return unless bundle_check != "The Gemfile's dependencies are satisfied"
 
-  puts bundle_check
-  print 'Install? [Yn] '
-  if $stdin.getch == 'n'
-    puts 'Exiting...'
-    exit
-  end
-  puts 'Installing...'
-
-  puts `bundle install`
+puts bundle_check
+print 'Install? [Yn] '
+if $stdin.getch == 'n'
+  puts 'Exiting...'
+  exit
 end
+puts 'Installing...'
 
-bundle_install_prompt
+puts `bundle install`
+
 
 require 'bundler/setup'
 Bundler.require


### PR DESCRIPTION
## Changes
- Users don't have to type enter after choosing to install or not the gems anymore
- Message telling the user the gems are being installed to avoid users thinking postwoman has crashed due to the lack of logging messages
- Wrapped this prompt in a method to visually separate this logic from the rest